### PR TITLE
Fix a few bugs.

### DIFF
--- a/src/dns.c
+++ b/src/dns.c
@@ -704,7 +704,7 @@ fill_name_in_msg(struct hlpc * h, uchar * to, int idx)
     for (i = idx - 1; i >= 0; i--) {
         m = reverse_compare(h[i].name, h[i].len, h[idx].name,
                             len);
-        if (m > h[i].mt) {
+        if (m > h[idx].mt) {
             h[idx].mt = m;      //max match
             h[idx].ref = i;
         }

--- a/src/dns.h
+++ b/src/dns.h
@@ -107,7 +107,7 @@ enum {
 #define GET_QR(flag) ((flag & 0x8000) / 0x8000)
 #define SET_QR_R(flag) (flag | 0x8000)
 #define SET_QR_Q(flag) (flag & 0x7fff)
-#define GET_OPCODE(flag) ((flag & 7800) >> 11)
+#define GET_OPCODE(flag) ((flag & 0x7800) >> 11)
 //we always set opcode 0 at current veserion.
 #define QUERY (0)
 #define IQUERY (1)


### PR DESCRIPTION
1. GET_OPCODE should use hex value 0x7800 not 7800.
2. Compare current h[idx].mt in each loop to get max match.