### PR TITLE
Improve message compression

### DIFF
--- a/src/author.c
+++ b/src/author.c
@@ -188,14 +188,12 @@ write_back_to_client(mbuf_type *mbuf, uchar * fr, int vlen)
     {
         type = from[0];
         mv = (struct mvalue *)(from + 1);
-        to = fill_rrset_in_msg(hlp, from, to, main_val, msg);
+        to = fill_rrset_in_msg(hlp, from, to, &main_val, msg);
         if (to == NULL)
             return -1;
 //         *to = 0;
         vlen = vlen - 1 - mv->len - sizeof(struct mvalue);
         sh.an += mv->num;
-        if (type == CNAME)      //cname must be 1
-            main_val++;             //no all rdata is the cname's
         from = from + mv->len + 1 + sizeof(struct mvalue);      // type.mv.len.
     }
     sh.itor = msg;

--- a/src/dns.c
+++ b/src/dns.c
@@ -905,9 +905,6 @@ fill_rrset_in_buffer(uchar * buffer, uchar * label, uchar * hdr, int lth,
         memcpy(buffer, label, 4);
         break;
     case NS:
-        get_domain_from_msg(label, hdr, buffer, &mlen);
-        to_lowercase(buffer, mlen);
-        break;
     case CNAME:
         get_domain_from_msg(label, hdr, buffer, &mlen);
         to_lowercase(buffer, mlen);

--- a/src/dns.c
+++ b/src/dns.c
@@ -580,12 +580,13 @@ get_level(uchar * itor)
 
 
 uchar *
-fill_all_records_in_msg(struct hlpc * h, struct hlpf * hf, int idx)
+fill_all_records_in_msg(struct hlpc * h, struct hlpf * hf, int *pidx)
 {
     int step = 0;
     uint16_t txtlen;
     uchar *tmp = NULL, *to = hf->to, *from = hf->from;
     struct fillmsg *fm = (struct fillmsg *) (hf->to);
+    int idx = *pidx;
     fm->type = htons(hf->type);
     fm->dclass = htons(CLASS_IN);
     fm->ttl = htonl(hf->ttl - global_now);
@@ -607,6 +608,7 @@ fill_all_records_in_msg(struct hlpc * h, struct hlpf * hf, int idx)
     case CNAME:
     case NS:
         idx++;
+        *pidx = idx;
         h[idx].name = from;
         h[idx].off = to - hf->hdr;
         h[idx].ref = -1;
@@ -622,6 +624,7 @@ fill_all_records_in_msg(struct hlpc * h, struct hlpf * hf, int idx)
         from += sizeof(uint16_t);       //2
         to += sizeof(uint16_t);
         idx++;
+        *pidx = idx;
         h[idx].name = from;
         h[idx].off = to - hf->hdr;
         h[idx].ref = -1;
@@ -644,6 +647,7 @@ fill_all_records_in_msg(struct hlpc * h, struct hlpf * hf, int idx)
         from += sizeof(uint16_t) * 3;
         to = to + sizeof(uint16_t) * 3;
         idx++;
+        *pidx = idx;
         h[idx].name = from;
         h[idx].off = to - hf->hdr;
         h[idx].ref = -1;
@@ -668,11 +672,11 @@ reverse_compare(uchar * from, int flen, uchar * to, int tolen)
 {
     uchar fi, ti, rec = 0;
     int match = 0;
-    flen -= 2;                  //1 for strlen + 1, 1 for array in c
-    tolen -= 2;
-    fi = from[flen];
-    ti = to[tolen];
-    while (flen && tolen) {
+    flen -= 1;                  //1 for strlen + 1
+    tolen -= 1;
+    do {
+        fi = from[--flen];
+        ti = to[--tolen];
         if (fi != ti)
             break;
         rec++;
@@ -681,9 +685,7 @@ reverse_compare(uchar * from, int flen, uchar * to, int tolen)
             match++;
             rec = 0;
         }
-        fi = from[--flen];
-        ti = to[--tolen];
-    }
+    } while (flen && tolen);
     return match;
 }
 
@@ -739,7 +741,7 @@ fill_name_in_msg(struct hlpc * h, uchar * to, int idx)
 
 //jump from author.c
 uchar *
-fill_rrset_in_msg(struct hlpc * h, uchar * from, uchar * to, int n,
+fill_rrset_in_msg(struct hlpc * h, uchar * from, uchar * to, int *pn,
                   uchar * hdr)
 {
     uchar type;
@@ -748,6 +750,7 @@ fill_rrset_in_msg(struct hlpc * h, uchar * from, uchar * to, int n,
     struct hlpf hf;
     int num = 0;
     struct mvalue *mv = NULL;
+    int n = *pn;
     type = from[0];
     from++;                     //type
     mv = (struct mvalue *) from;
@@ -763,6 +766,20 @@ fill_rrset_in_msg(struct hlpc * h, uchar * from, uchar * to, int n,
         step = 4;
     if (type == AAAA)
         step = 16;
+    /**
+     * A & AAA use previous domain name (question name or cname name).
+     * We duplicate here to make it possible to refer previous one.
+     */
+    if (type == A || type == AAAA) {
+        n++;
+        *pn = n;
+        h[n].name = h[n - 1].name;
+        h[n].off = h[n - 1].off;
+        h[n].level = h[n - 1].level;
+        h[n].len = h[n - 1].len;
+        h[n].ref = -1;
+        h[n].mt = 0;
+    }
     switch (type)               //7
     {
     case A:
@@ -775,7 +792,7 @@ fill_rrset_in_msg(struct hlpc * h, uchar * from, uchar * to, int n,
             //then we get ttl's position
             //plus hdr we get it's offset
             //only for A record
-            to = fill_all_records_in_msg(h, &hf, n);
+            to = fill_all_records_in_msg(h, &hf, pn);
             from += step;
         }
         return to;
@@ -785,7 +802,7 @@ fill_rrset_in_msg(struct hlpc * h, uchar * from, uchar * to, int n,
         hf.from = from;
         hf.to = to;
         hf.len = strlen((const char *)from) + 1;
-        to = fill_all_records_in_msg(h, &hf, n);
+        to = fill_all_records_in_msg(h, &hf, pn);
         return to;
         break;
     case NS:
@@ -795,7 +812,7 @@ fill_rrset_in_msg(struct hlpc * h, uchar * from, uchar * to, int n,
             hf.from = from;
             hf.to = to;
             hf.len = strlen((const char *)from) + 1;
-            to = fill_all_records_in_msg(h, &hf, n);
+            to = fill_all_records_in_msg(h, &hf, pn);
             from += hf.len;//strlen((const char *)from) + 1;
         }
         return to;
@@ -806,7 +823,7 @@ fill_rrset_in_msg(struct hlpc * h, uchar * from, uchar * to, int n,
             hf.from = from;
             hf.to = to;
             hf.len = strlen((const char *)(from + sizeof(uint16_t))) + 1;
-            to = fill_all_records_in_msg(h, &hf, n + i);
+            to = fill_all_records_in_msg(h, &hf, pn);
             from += sizeof(uint16_t);   //jump ref
             from += hf.len;//strlen((const char *)from) + 1;   //jump name and tail 0
         }
@@ -819,7 +836,7 @@ fill_rrset_in_msg(struct hlpc * h, uchar * from, uchar * to, int n,
             to = fill_name_in_msg(h, to, n);
             hf.from = from;
             hf.to = to;
-            to = fill_all_records_in_msg(h, &hf, n);
+            to = fill_all_records_in_msg(h, &hf, pn);
             from = from + txtlen + sizeof(uint16_t);
         }
         return to;
@@ -830,7 +847,7 @@ fill_rrset_in_msg(struct hlpc * h, uchar * from, uchar * to, int n,
             hf.from = from;
             hf.to = to;
             hf.len = strlen((const char *)(from + sizeof(uint16_t) * 3))  + 1;
-            to = fill_all_records_in_msg(h, &hf, n);
+            to = fill_all_records_in_msg(h, &hf, pn);
             from += sizeof(uint16_t) * 3;       //pri wei port
             from += hf.len;//strlen((const char *)from) + 1;   //target
         }

--- a/src/dns.h
+++ b/src/dns.h
@@ -323,7 +323,7 @@ int find_addr(struct htable *fwd, struct htable *, mbuf_type *mbuf,
 
 
 uchar *fill_header_in_msg(struct setheader *);
-uchar *fill_rrset_in_msg(struct hlpc *, uchar *, uchar *, int, uchar *);
+uchar *fill_rrset_in_msg(struct hlpc *, uchar *, uchar *, int *, uchar *);
 
 uint dname_hash(void *);
 


### PR DESCRIPTION
## reverse_compare

reverse_compare 有个 bug，修复了，以前是无法比较第一个 label 的，会导致 compare("a.b.c.", "a.b.c.") 是 2 不是 3 。

```c
while (flen && tolen) {
    if (fi != ti) {
        break;
    }
    // ...removed
    // 当这里取到第一字符时，下次 loop 就直接退出了，而没有进行比较
    fi = from[--flen];
    ti = to[--tolen];
}
```

## DNS compression

DNS response 中的域名有些情况下，没有完全压缩，下面是个例子:

```
$ dig www.xd.com @localhost
```

**修改之前：**

```
header & question:
01 86 80 80 00 01 00 02 00 00 00 00 03 77 77 77 02 78 64 03 63 6f 6d 00 00 01 00 01
record 1:
c0 0c 00 05 00 01 00 00 00 ca 00 09 03 61 30 31 02 6c 62 c0 10  # www.xd.com. -> a01.lb.xd.com.
record 2: 
03 61 30 31 02 6c 62 c0 10 00 01 00 01 00 00 02 06 00 04 df ca 1a 13 # a01.lb.xd.com. -> 223.202.26.19
```

record 2 没有直接指向 record 1 rdata 中的域名，这两者其实是完全一样的。

**修改之后：**

```
header & question:
bf c2 80 80 00 01 00 02 00 00 00 00 03 77 77 77 02 78 64 03 63 6f 6d 00 00 01 00 01
record 1:
c0 0c 00 05 00 01 00 00 01 43 00 09 03 61 30 31 02 6c 62 c0 10
record 2:
c0 28 00 01 00 00 60  01 00 00 02 7f 00 04 df ca 1a 13
```

现在 record 2 中 "c0 28" 直接指向了 record 1 中的域名（a01.lb.xd.com.)，字节数这里减少了 5 。


这个 pr 里我做的修复尝试，主要是维护全局的域名索引，让下次要填入的域名可以重用所有前面已经写入的域名。

不过，我没有很完善地测试，不清楚是否某些场景有问题，你们看下？